### PR TITLE
Fix typo, form name, docs and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Instead, it will copy all the configuration files and the transitive dependencie
 
 You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
 
+## Local Backend
+
+This application expects a JSON server running on `http://localhost:3001/`. The
+repository contains a `data/db.json` file with sample data. Start the server with:
+
+```bash
+json-server --watch data/db.json -p 3001
+```
+
+Once running, the React application will be able to fetch dishes, leaders and
+other resources from the backend.
+
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders header text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Ristorante con Fusion/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/DishdetailComponent.js
+++ b/src/components/DishdetailComponent.js
@@ -168,8 +168,8 @@ import { FadeTransform, Fade, Stagger } from 'react-animation-components';
                         <Row className="form-group">
                             <Label htmlFor="author" md={12}>Your Name</Label>
                             <Col md={12}>
-                            <Control.text model=".author" id="author" name="name"
-                                innerRef={(input) => this.author = input} 
+                            <Control.text model=".author" id="author" name="author"
+                                innerRef={(input) => this.author = input}
                                 validators={{
                                     required, minLength: minLength(3), maxLength: maxLength(15)
                                 }}

--- a/src/shared/leaders.js
+++ b/src/shared/leaders.js
@@ -6,7 +6,7 @@ export const LEADERS = [
       designation: 'Chief Epicurious Officer',
       abbr: 'CEO',
       featured: false,
-      description: "Our CEO, Peter, credits his hardworking East Asian immigrant parents who undertook the arduous journey to the shores of America with the intention of giving their children the best future. His mother's wizardy in the kitchen whipping up the tastiest dishes with whatever is available inexpensively at the supermarket, was his first inspiration to create the fusion cuisines for which The Frying Pan became well known. He brings his zeal for fusion cuisines to this restaurant, pioneering cross-cultural culinary connections."
+      description: "Our CEO, Peter, credits his hardworking East Asian immigrant parents who undertook the arduous journey to the shores of America with the intention of giving their children the best future. His mother's wizardry in the kitchen whipping up the tastiest dishes with whatever is available inexpensively at the supermarket, was his first inspiration to create the fusion cuisines for which The Frying Pan became well known. He brings his zeal for fusion cuisines to this restaurant, pioneering cross-cultural culinary connections."
     },
     {
       id: 1,


### PR DESCRIPTION
## Summary
- correct `wizardry` typo in leaders data
- fix author field name in dish detail form
- document local JSON server backend setup
- update default App test to check header text

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644a440430832694d6b95ede3fd2ea